### PR TITLE
Add GitHub Actions CI build with git SHA in firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build Firmware
+
+on:
+  push:
+  pull_request:
+
+env:
+  PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Checkout pico-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: raspberrypi/pico-sdk
+          ref: '1.5.1'
+          path: pico-sdk
+          submodules: true
+
+      - name: Install ARM toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: '13.3.Rel1'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake build-essential
+
+      - name: Determine short SHA
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Configure
+        run: >
+          cmake -B FW/i2c_responder/build -S FW/i2c_responder
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_SHA=${{ env.SHORT_SHA }}
+
+      - name: Build
+        run: cmake --build FW/i2c_responder/build --parallel $(nproc)
+
+      - name: Upload firmware
+        uses: actions/upload-artifact@v4
+        with:
+          name: jog2k-${{ env.SHORT_SHA }}
+          path: FW/i2c_responder/build/jog2k-${{ env.SHORT_SHA }}.uf2
+          if-no-files-found: error

--- a/FW/i2c_responder/CMakeLists.txt
+++ b/FW/i2c_responder/CMakeLists.txt
@@ -22,6 +22,14 @@ pico_generate_pio_header(app_main  ${CMAKE_CURRENT_LIST_DIR}/ws2812byte.pio)
 pico_enable_stdio_usb(app_main 1)
 pico_enable_stdio_uart(app_main 1)
 pico_add_extra_outputs(app_main)
+
+if(DEFINED BUILD_SHA)
+    target_compile_definitions(app_main PRIVATE BUILD_SHA="${BUILD_SHA}")
+    set_target_properties(app_main PROPERTIES OUTPUT_NAME "jog2k-${BUILD_SHA}")
+else()
+    set_target_properties(app_main PROPERTIES OUTPUT_NAME "jog2k")
+endif()
+
 # Pull in pico libraries that we need
 # target_link_libraries(pico_neopixel INTERFACE pico_stdlib hardware_pio pico_malloc pico_mem_ops)
 target_link_libraries(app_main i2c_slave pico_stdlib hardware_i2c pico_stdlib hardware_pio pico_malloc pico_mem_ops)

--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -893,7 +893,7 @@ rc = oledInit(&oled, OLED_128x64, 0x3c, screenflip, 0, 0, SDA_PIN, SCL_PIN, RESE
 oledSetBackBuffer(&oled, ucBuffer);
 oledFill(&oled, 0,1);
 oledWriteString(&oled, 0,0,1,(char *)"JOG2K", FONT_12x16, 0, 1);
-oledWriteString(&oled, 0,0,4,(char *)JOG2K_VERSION, FONT_12x16, 0, 1);
+oledWriteString(&oled, 0,0,4,(char *)JOG2K_VERSION, FONT_8x8, 0, 1);
 oledWriteString(&oled, 0,0,7,(char *)PLUGIN_VERSION, FONT_6x8, 0, 1);
 sleep_ms(1000);
 oledFill(&oled, 0,1);

--- a/FW/i2c_responder/i2c_jogger.h
+++ b/FW/i2c_responder/i2c_jogger.h
@@ -2,7 +2,13 @@
 #define __I2C_JOGGER_H__
 
 #define PLUGIN_VERSION "PLUGIN: Keypad v1.41"
-#define JOG2K_VERSION  "FW: v1.1.0"
+#define JOG2K_FW_VERSION "1.1.0"
+
+#ifndef BUILD_SHA
+#define BUILD_SHA "dev"
+#endif
+
+#define JOG2K_VERSION "v" JOG2K_FW_VERSION "+" BUILD_SHA
 
 // Which pin on the Arduino is connected to the NeoPixels?
 #define PIN        22 // On Trinket or Gemma, suggest changing this to 1


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds the firmware on every push and PR using pico-sdk 1.5.1 and ARM GCC 13.3
- Embed the short git SHA at compile time (`-DBUILD_SHA`) so the OLED boot splash shows the exact build, e.g. `v1.1.0+abc1234` (local builds show `v1.1.0+dev`)
- Rename the output binary from `app_main.uf2` to `jog2k-<sha>.uf2` for easy identification
- Upload the built UF2 as a GitHub Actions artifact

## Changes
- **`.github/workflows/build.yml`** — New CI workflow
- **`FW/i2c_responder/CMakeLists.txt`** — Handle optional `BUILD_SHA` define and rename output binary
- **`FW/i2c_responder/i2c_jogger.h`** — Compose `JOG2K_VERSION` from version + build SHA
- **`FW/i2c_responder/app_main.cpp`** — Use smaller font for the now-longer version string on boot splash

I've tested the resulting firmware builds and they work as expected.