### PR TITLE
PR status struct v2

### DIFF
--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -728,6 +728,7 @@ static void draw_main_screen(bool force){
           //only re-fill the screen if the state or alarm code have changed.
           if( (prev_packet.machine_substate != packet->machine_substate) || (prev_packet.machine_state != packet->machine_state) )
             oledFill(&oled, 0,1);
+            prev_packet.machine_substate = packet->machine_substate;
           oledWriteString(&oled, 0,0,0,(char *)" *****************", FONT_6x8, 0, 1);
           oledWriteString(&oled, 0,0,7,(char *)" *****************", FONT_6x8, 0, 1);
           //no jog during hold
@@ -757,6 +758,7 @@ static void draw_main_screen(bool force){
         break; //close default case
       }//close machine_state switch statement
   }//close screen mode switch statement
+  packet->machine_substate = prev_packet.machine_substate;
   prev_packet = *packet;
   // previous_jogmode = current_jogmode;
   // previous_jogmodify = current_jogmodify;

--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -515,21 +515,33 @@ static void draw_main_screen(bool force){
            packet->coordinate.y != previous_packet->coordinate.y || 
            packet->coordinate.z != previous_packet->coordinate.z || 
            packet->coordinate.a != previous_packet->coordinate.a || force){
-          sprintf(charbuf, "X %8.3F", packet->coordinate.x);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "X %8.4F", packet->coordinate.x);
+          else
+            sprintf(charbuf, "X %8.3F", packet->coordinate.x);
           oledWriteString(&oled, 0,0,2,charbuf, FONT_8x8, 0, 1);
           //}
           //oledWriteString(&oled, 2,0,3,(char *)"        ", FONT_8x8, 0, 1);
           //if(packet->y_coordinate != previous_packet.y_coordinate || force){ 
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Y %8.4F", packet->coordinate.y);
+          else
             sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
-            oledWriteString(&oled, 0,0,3,charbuf, FONT_8x8, 0, 1);
+          oledWriteString(&oled, 0,0,3,charbuf, FONT_8x8, 0, 1);
           //}
           //oledWriteString(&oled, 2,0,4,(char *)"        ", FONT_8x8, 0, 1);
           //if(packet->z_coordinate != previous_packet.z_coordinate || force){ 
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Z %8.4F", packet->coordinate.z);
+          else
             sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
-            oledWriteString(&oled, 0,0,4,charbuf, FONT_8x8, 0, 1);
+          oledWriteString(&oled, 0,0,4,charbuf, FONT_8x8, 0, 1);
           //}
           if(!isnan(packet->coordinate.a)){          
-            sprintf(charbuf, "A %8.3F", packet->coordinate.a);
+            if(packet->machine_modes.imperial == 1)
+              sprintf(charbuf, "A %8.4F", packet->coordinate.a);
+            else
+              sprintf(charbuf, "A %8.3F", packet->coordinate.a);
             oledWriteString(&oled, 0,0,5,charbuf, FONT_8x8, 0, 1);
           }else if (command_error){
             sprintf(charbuf, "COMMAND ERR", packet->coordinate.a);
@@ -568,16 +580,28 @@ static void draw_main_screen(bool force){
           oledWriteString(&oled, 0,-1,-1,(char *)"RUN  ", FONT_6x8, 0, 1); 
 
           oledWriteString(&oled, 2,0,2,(char *)"        ", FONT_8x8, 0, 1); 
-          sprintf(charbuf, "X %8.3F", packet->coordinate.x);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "X %8.4F", packet->coordinate.x);
+          else
+            sprintf(charbuf, "X %8.3F", packet->coordinate.x);
           oledWriteString(&oled, 0,0,2,charbuf, FONT_8x8, 0, 1);
           oledWriteString(&oled, 2,0,3,(char *)"        ", FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Y %8.4F", packet->coordinate.y);
+          else
+            sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
           oledWriteString(&oled, 0,0,3,charbuf, FONT_8x8, 0, 1);
           oledWriteString(&oled, 2,0,4,(char *)"        ", FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Z %8.4F", packet->coordinate.z);
+          else
+            sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
           oledWriteString(&oled, 0,0,4,charbuf, FONT_8x8, 0, 1);
-          if(!isnan(packet->coordinate.a)){ 
-            sprintf(charbuf, "A %8.3F", packet->coordinate.a);
+          if(!isnan(packet->coordinate.a)){          
+            if(packet->machine_modes.imperial == 1)
+              sprintf(charbuf, "A %8.4F", packet->coordinate.a);
+            else
+              sprintf(charbuf, "A %8.3F", packet->coordinate.a);
             oledWriteString(&oled, 0,0,5,charbuf, FONT_8x8, 0, 1);
           }else{
             sprintf(charbuf, "          ", packet->coordinate.a);
@@ -604,14 +628,26 @@ static void draw_main_screen(bool force){
           oledWriteString(&oled, 0,0,2,(char *)"                G", FONT_6x8, 0, 1);
           oledWriteString(&oled, 0,-1,-1,map_coord_system(packet->current_wcs), FONT_6x8, 0, 1);   
 
-          sprintf(charbuf, "X %8.3F", packet->coordinate.x);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "X %8.4F", packet->coordinate.x);
+          else
+            sprintf(charbuf, "X %8.3F", packet->coordinate.x);
           oledWriteString(&oled, 0,0,2,charbuf, FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Y %8.4F", packet->coordinate.y);
+          else
+            sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
           oledWriteString(&oled, 0,0,3,charbuf, FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Z %8.4F", packet->coordinate.z);
+          else
+            sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
           oledWriteString(&oled, 0,0,4,charbuf, FONT_8x8, 0, 1);
-          if(!isnan(packet->coordinate.a)){ 
-            sprintf(charbuf, "A %8.3F", packet->coordinate.a);
+          if(!isnan(packet->coordinate.a)){          
+            if(packet->machine_modes.imperial == 1)
+              sprintf(charbuf, "A %8.4F", packet->coordinate.a);
+            else
+              sprintf(charbuf, "A %8.3F", packet->coordinate.a);
             oledWriteString(&oled, 0,0,5,charbuf, FONT_8x8, 0, 1);
           }else{
             sprintf(charbuf, "          ", packet->coordinate.a);
@@ -650,14 +686,26 @@ static void draw_main_screen(bool force){
           oledWriteString(&oled, 0,0,2,(char *)"                G", FONT_6x8, 0, 1);
           oledWriteString(&oled, 0,-1,-1,map_coord_system(packet->current_wcs), FONT_6x8, 0, 1);             
 
-          sprintf(charbuf, "X %8.3F", packet->coordinate.x);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "X %8.4F", packet->coordinate.x);
+          else
+            sprintf(charbuf, "X %8.3F", packet->coordinate.x);
           oledWriteString(&oled, 0,0,2,charbuf, FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Y %8.4F", packet->coordinate.y);
+          else
+            sprintf(charbuf, "Y %8.3F", packet->coordinate.y);
           oledWriteString(&oled, 0,0,3,charbuf, FONT_8x8, 0, 1); 
-          sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
+          if(packet->machine_modes.imperial == 1)
+            sprintf(charbuf, "Z %8.4F", packet->coordinate.z);
+          else
+            sprintf(charbuf, "Z %8.3F", packet->coordinate.z);
           oledWriteString(&oled, 0,0,4,charbuf, FONT_8x8, 0, 1);         
-          if(!isnan(packet->coordinate.a)){ 
-            sprintf(charbuf, "A %8.3F", packet->coordinate.a);
+          if(!isnan(packet->coordinate.a)){          
+            if(packet->machine_modes.imperial == 1)
+              sprintf(charbuf, "A %8.4F", packet->coordinate.a);
+            else
+              sprintf(charbuf, "A %8.3F", packet->coordinate.a);
             oledWriteString(&oled, 0,0,5,charbuf, FONT_8x8, 0, 1);
           }else{
             sprintf(charbuf, "          ", packet->coordinate.a);

--- a/FW/i2c_responder/i2c_jogger.h
+++ b/FW/i2c_responder/i2c_jogger.h
@@ -235,7 +235,7 @@ typedef union {
         uint8_t flood          :1, //!< Flood coolant.
                 mist           :1, //!< Mist coolant, optional.
                 shower         :1, //!< Shower coolant, currently unused.
-                trough_spindle :1, //!< Through spindle coolant, currently unused.
+                through_spindle :1, //!< Through spindle coolant, currently unused.
                 unused         :4;
     };
 } coolant_state_t;
@@ -279,17 +279,20 @@ enum msg_type_t {
     MachineMsg_ClearMessage = 255,
 };
 
-enum machine_state_t {
-    MachineState_Alarm = 1,
-    MachineState_Cycle = 2,
-    MachineState_Hold = 3,
-    MachineState_ToolChange = 4,
-    MachineState_Idle = 5,
-    MachineState_Homing = 6,
-    MachineState_Jog = 7,
-    // MachineState_Reset = 8,
-    MachineState_Other = 254
-};
+typedef enum {
+    SystemState_Idle = 0,
+    SystemState_Alarm = 1,
+    SystemState_CheckMode = 2,
+    SystemState_Homing = 3,
+    SystemState_Cycle = 4,
+    SystemState_Hold = 5,
+    SystemState_Jog = 6,
+    SystemState_DoorOpen = 7,
+    SystemState_Sleep = 8,
+    SystemState_EStop = 9,
+    SystemState_ToolChange = 10,
+    SystemState_Undefined = 255
+} system_state_t; //__attribute__ ((__packed__)) 
 
 typedef union {
     uint8_t mask;
@@ -361,8 +364,9 @@ typedef union {
                 mpg            :1,
                 homed          :1,
                 tlo_referenced :1,
-                imperial       :1,
-                mode           :3; // from machine_mode_t setting
+                mode             :2, // from machine_mode_t setting
+                reports_imperial :1, // $13=1
+                imperial         :1; // G20 active
     };
 } machine_modes_t;
 
@@ -478,9 +482,9 @@ typedef enum {
 } __attribute__ ((__packed__)) status_code_t;
 
 typedef struct {
-    uint8_t address;
-    machine_state_t machine_state;
-    uint8_t machine_substate;
+    uint8_t version;
+    system_state_t system_state;
+    uint8_t system_substate;
     axes_signals_t home_state;
     uint8_t feed_override; // size changed in latest version!
     uint8_t spindle_override;

--- a/FW/i2c_responder/i2c_jogger.h
+++ b/FW/i2c_responder/i2c_jogger.h
@@ -1,8 +1,8 @@
 #ifndef __I2C_JOGGER_H__
 #define __I2C_JOGGER_H__
 
-#define PLUGIN_VERSION "PLUGIN: Keypad v1.41"
-#define JOG2K_FW_VERSION "1.1.0"
+#define PLUGIN_VERSION "PLUGIN: Keypad v1.44"
+#define JOG2K_FW_VERSION "1.2.0"
 
 #ifndef BUILD_SHA
 #define BUILD_SHA "dev"
@@ -361,6 +361,7 @@ typedef union {
                 mpg            :1,
                 homed          :1,
                 tlo_referenced :1,
+                imperial       :1,
                 mode           :3; // from machine_mode_t setting
     };
 } machine_modes_t;


### PR DESCRIPTION
Add support for the following upstream changes / features:

- v2 of status struct in latest keypad plugin
- reporting of imperial units when `machine_modes.reports_imperial` flag (linked to [setting](https://github.com/grblHAL/core/blob/e0896a9db02c5487454edc0e582d5db4bcb15c26/settings.h#L61) `$13`) is set to 1